### PR TITLE
fix: auto-rebuild native modules on install

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "test": "bunx playwright test --project=electron",
     "rebuild": "bunx electron-rebuild",
     "dist": "electron-vite build && electron-builder --mac --arm64",
-    "postinstall": "bash scripts/patch-electron-dev.sh"
+    "postinstall": "bash scripts/patch-electron-dev.sh && bunx electron-rebuild"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- Add `electron-rebuild` to the `postinstall` script so native modules (node-pty) are automatically compiled against Electron's Node.js version after `bun install`
- Fixes `posix_spawnp failed` errors when opening terminal tabs after a fresh clone