### PR TITLE
fix: refresh changes tab on external commits

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -186,7 +186,9 @@ export function registerIpcHandlers(): void {
     try {
       const watcher = watch(dirPath, { recursive: true }, (_eventType, filename) => {
         // Ignore .git internal changes
-        if (filename && (filename.startsWith('.git/') || filename.startsWith('.git\\'))) return
+        if (filename && (filename.startsWith('.git/') || filename.startsWith('.git\\'))) {
+          if (filename !== '.git/index' && filename !== '.git\\index') return
+        }
 
         const entry = fsWatchers.get(dirPath)
         if (!entry) return


### PR DESCRIPTION
## Summary
- The FS watcher filtered out all `.git/` directory changes, so commits made from the terminal (or Claude Code) never triggered a refresh of the Changes tab
- Allow `.git/index` through the filter — it changes on every stage/commit operation, which is exactly when git status needs refreshing
- Existing 500ms debounce prevents any flooding

## Test plan
- [ ] Open a workspace with changes in the Changes tab
- [ ] Commit from the terminal (not the UI button)
- [ ] Verify the Changes tab updates within ~500ms