### PR TITLE
Pi agent loading indicator

### DIFF
--- a/desktop/e2e/pi-mono-json-exit-stuck.spec.ts
+++ b/desktop/e2e/pi-mono-json-exit-stuck.spec.ts
@@ -1,0 +1,92 @@
+import { test, type Page } from '@playwright/test'
+import { join } from 'path'
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { execSync } from 'child_process'
+import { launchControlledApp } from './helpers/electron-app-driver'
+
+function createTestRepo(name: string): string {
+  const stamp = `${name}-${Date.now()}`
+  const repoPath = join('/tmp', `test-repo-${stamp}`)
+  mkdirSync(repoPath, { recursive: true })
+  execSync('git init', { cwd: repoPath })
+  execSync('git checkout -b main', { cwd: repoPath })
+  writeFileSync(join(repoPath, 'README.md'), '# Test Repo\n')
+  execSync('git add .', { cwd: repoPath })
+  execSync('git commit -m "initial commit"', { cwd: repoPath })
+  return repoPath
+}
+
+async function setupWorkspace(window: Page, repoPath: string) {
+  return await window.evaluate(async (repo: string) => {
+    const store = (window as any).__store.getState()
+    store.hydrateState({ projects: [], workspaces: [] })
+
+    const projectId = crypto.randomUUID()
+    store.addProject({ id: projectId, name: 'test-repo', repoPath: repo })
+
+    const wt1 = await (window as any).api.git.createWorktree(repo, 'ws-pi-exit', 'branch-pi-exit', true, 'main')
+    const ws1Id = crypto.randomUUID()
+    store.addWorkspace({ id: ws1Id, name: 'ws-pi-exit', branch: 'branch-pi-exit', worktreePath: wt1, projectId })
+    const pty1Id = await (window as any).api.pty.create(wt1, '/bin/bash', { AGENT_ORCH_WS_ID: ws1Id })
+    store.addTab({ id: crypto.randomUUID(), workspaceId: ws1Id, type: 'terminal', title: 'Terminal', ptyId: pty1Id })
+
+    const wt2 = await (window as any).api.git.createWorktree(repo, 'ws-pi-other', 'branch-pi-other', true, 'main')
+    const ws2Id = crypto.randomUUID()
+    store.addWorkspace({ id: ws2Id, name: 'ws-pi-other', branch: 'branch-pi-other', worktreePath: wt2, projectId })
+    const pty2Id = await (window as any).api.pty.create(wt2, '/bin/bash', { AGENT_ORCH_WS_ID: ws2Id })
+    store.addTab({ id: crypto.randomUUID(), workspaceId: ws2Id, type: 'terminal', title: 'Terminal', ptyId: pty2Id })
+
+    store.setActiveWorkspace(ws2Id)
+
+    return { ws1Id, pty1Id, ws2Id, pty2Id }
+  }, repoPath)
+}
+
+function writeIncompletePiMonoJsonScript(scriptPath: string): void {
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash
+printf '{"type":"session","version":3,"id":"pi-json-session-exit","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}\\n'
+printf '{"type":"agent_start"}\\n'
+printf '{"type":"turn_start"}\\n'
+printf '{"type":"turn_end","message":{"role":"assistant","content":[]},"toolResults":[]}'
+exit 0
+`,
+    { mode: 0o755 },
+  )
+  chmodSync(scriptPath, 0o755)
+}
+
+test.describe('Pi-mono JSON trailing turn_end handling', () => {
+  test('does not stay active when final turn_end is not newline-terminated', async () => {
+    const repoPath = createTestRepo('pi-mono-json-exit')
+    const { app, window, eventDir } = await launchControlledApp('pi-mono-json-exit')
+    const scriptPath = join('/tmp', `fake-pi-mono-json-exit-${Date.now()}.sh`)
+
+    try {
+      writeIncompletePiMonoJsonScript(scriptPath)
+      const { ws1Id, pty1Id } = await setupWorkspace(window, repoPath)
+      await window.waitForTimeout(600)
+
+      await window.evaluate(({ ptyId, cmd }) => {
+        ;(window as any).api.pty.write(ptyId, `${cmd}\n`)
+      }, { ptyId: pty1Id, cmd: scriptPath })
+
+      await window.waitForFunction(
+        (wsId: string) => (window as any).__store.getState().unreadWorkspaceIds.has(wsId),
+        ws1Id,
+        { timeout: 15000 },
+      )
+
+      await window.waitForFunction(
+        (wsId: string) => !(window as any).__store.getState().activeAgentWorkspaceIds.has(wsId),
+        ws1Id,
+        { timeout: 5000 },
+      )
+    } finally {
+      await app.close()
+      rmSync(scriptPath, { force: true })
+      rmSync(eventDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/desktop/src/main/notification-watcher.ts
+++ b/desktop/src/main/notification-watcher.ts
@@ -7,6 +7,10 @@ import { AGENT_EVENT_DEFAULT_DIR } from './agent-events'
 
 const POLL_INTERVAL = 500
 const FILE_SETTLE_MS = 100
+const TURN_EVENT_ORDER: Record<AgentTurnEventType, number> = {
+  turn_started: 0,
+  awaiting_user: 1,
+}
 
 const TURN_EVENT_TYPES: AgentTurnEventType[] = ['turn_started', 'awaiting_user']
 const TURN_OUTCOMES: AgentTurnOutcome[] = ['success', 'failed']
@@ -50,6 +54,8 @@ export class NotificationWatcher {
     try {
       const files = readdirSync(this.eventDir)
       const now = Date.now()
+      const pendingEvents: Array<{ filePath: string; event: AgentTurnEvent }> = []
+      const processedPaths: string[] = []
       for (const f of files) {
         if (f.endsWith('.tmp')) continue
         const filePath = join(this.eventDir, f)
@@ -59,33 +65,44 @@ export class NotificationWatcher {
         } catch {
           continue
         }
-        this.processAgentEventFile(filePath)
+        processedPaths.push(filePath)
+        const event = this.readAgentEventFile(filePath)
+        if (event) pendingEvents.push({ filePath, event })
+      }
+
+      pendingEvents.sort((a, b) => {
+        const atDiff = (a.event.at ?? 0) - (b.event.at ?? 0)
+        if (atDiff !== 0) return atDiff
+        const typeDiff = TURN_EVENT_ORDER[a.event.type] - TURN_EVENT_ORDER[b.event.type]
+        if (typeDiff !== 0) return typeDiff
+        return a.filePath.localeCompare(b.filePath)
+      })
+
+      for (const entry of pendingEvents) {
+        this.applyEvent(entry.event)
+      }
+
+      for (const filePath of processedPaths) {
+        try {
+          unlinkSync(filePath)
+        } catch {
+          // Ignore unlink failures.
+        }
       }
     } catch {
       // Directory may not exist yet
     }
   }
 
-  private processAgentEventFile(filePath: string): void {
+  private readAgentEventFile(filePath: string): AgentTurnEvent | null {
     try {
       const raw = readFileSync(filePath, 'utf-8').trim()
-      if (!raw) {
-        unlinkSync(filePath)
-        return
-      }
+      if (!raw) return null
 
       const parsed = JSON.parse(raw) as Partial<AgentTurnEvent>
-      const event = this.normalizeEvent(parsed)
-      if (event) {
-        this.applyEvent(event)
-      }
-      unlinkSync(filePath)
+      return this.normalizeEvent(parsed)
     } catch {
-      try {
-        unlinkSync(filePath)
-      } catch {
-        // Ignore unlink failures.
-      }
+      return null
     }
   }
 
@@ -124,10 +141,12 @@ export class NotificationWatcher {
 
     if (type === 'turn_started') {
       this.addActiveSession(workspaceId, this.sessionKey(agent, sessionId))
+      this.publishActivity()
       return
     }
 
     this.removeActiveSession(workspaceId, agent, sessionId)
+    this.publishActivity()
     this.notifyRenderer(workspaceId)
   }
 
@@ -170,12 +189,12 @@ export class NotificationWatcher {
       if (sessions.size > 0) nextActive.add(workspaceId)
     }
 
-    if (this.equalSets(nextActive, this.lastPublishedActiveIds)) return
-
     const becameInactive: string[] = []
     for (const wsId of this.lastPublishedActiveIds) {
       if (!nextActive.has(wsId)) becameInactive.push(wsId)
     }
+
+    if (this.equalSets(nextActive, this.lastPublishedActiveIds)) return
 
     this.lastPublishedActiveIds = nextActive
     this.sendActivity(Array.from(nextActive).sort())

--- a/desktop/src/main/pty-manager.ts
+++ b/desktop/src/main/pty-manager.ts
@@ -125,6 +125,54 @@ function stripAnsiSequences(data: string): string {
     .replace(/\x1bP.*?\x1b\\/g, '')
 }
 
+function extractLeadingJsonObject(buffer: string): { json: string; remainder: string } | null {
+  let start = 0
+  while (start < buffer.length && /\s/.test(buffer[start])) start += 1
+  if (start >= buffer.length || buffer[start] !== '{') return null
+
+  let depth = 0
+  let inString = false
+  let isEscaped = false
+
+  for (let i = start; i < buffer.length; i += 1) {
+    const char = buffer[i]
+    if (inString) {
+      if (isEscaped) {
+        isEscaped = false
+        continue
+      }
+      if (char === '\\') {
+        isEscaped = true
+        continue
+      }
+      if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return {
+          json: buffer.slice(start, i + 1),
+          remainder: buffer.slice(i + 1),
+        }
+      }
+    }
+  }
+
+  return null
+}
+
 function appendReplayChunk(instance: PtyInstance, chunk: string): void {
   if (!chunk) return
 
@@ -387,6 +435,12 @@ export class PtyManager {
 
     const lines = instance.agentEventLineBuffer.split(/\r?\n|\r/)
     instance.agentEventLineBuffer = lines.pop() ?? ''
+    let bufferedJson = extractLeadingJsonObject(instance.agentEventLineBuffer)
+    while (bufferedJson) {
+      lines.push(bufferedJson.json)
+      instance.agentEventLineBuffer = bufferedJson.remainder
+      bufferedJson = extractLeadingJsonObject(instance.agentEventLineBuffer)
+    }
 
     for (const rawLine of lines) {
       const line = rawLine.trim()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix Pi activity indicator getting stuck by ensuring `turn_end` events are always processed and agent state transitions are correctly ordered.

The indicator would get stuck because the final `turn_end` event could be buffered if not newline-terminated, preventing the "done" transition. Additionally, incorrect ordering of agent events could lead to `awaiting_user` being applied before `turn_started`, leaving Pi active.

---
<p><a href="https://cursor.com/agents/bc-d40fa751-fd5d-4850-92b7-47aed4e8df40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40fa751-fd5d-4850-92b7-47aed4e8df40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->