### PR TITLE
feat: add drag-to-reorder for workspaces in sidebar

### DIFF
--- a/desktop/src/renderer/components/Sidebar/Sidebar.module.css
+++ b/desktop/src/renderer/components/Sidebar/Sidebar.module.css
@@ -625,6 +625,15 @@
   to { transform: rotate(360deg); }
 }
 
+/* Workspace drag-to-reorder */
+.workspaceItem.wsDragging {
+  opacity: 0.4;
+}
+
+.workspaceItem.wsDragOver {
+  box-shadow: inset 0 -2px 0 0 var(--accent-blue);
+}
+
 /* Root workspace — subtle distinction */
 .rootWorkspace .workspaceIcon {
   font-weight: var(--weight-semibold);

--- a/desktop/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/desktop/src/renderer/components/Sidebar/Sidebar.tsx
@@ -280,6 +280,7 @@ export function Sidebar() {
   const unreadWorkspaceIds = useAppStore((s) => s.unreadWorkspaceIds);
   const activeAgentWorkspaceIds = useAppStore((s) => s.activeAgentWorkspaceIds);
   const renameWorkspace = useAppStore((s) => s.renameWorkspace);
+  const reorderWorkspace = useAppStore((s) => s.reorderWorkspace);
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const setPrStatuses = useAppStore((s) => s.setPrStatuses);
   const setGhAvailability = useAppStore((s) => s.setGhAvailability);
@@ -308,6 +309,9 @@ export function Sidebar() {
   >({});
   const [pullingPrKey, setPullingPrKey] = useState<string | null>(null);
   const [projectPrSearch, setProjectPrSearch] = useState("");
+  const [draggingWsId, setDraggingWsId] = useState<string | null>(null);
+  const [dragOverWsId, setDragOverWsId] = useState<string | null>(null);
+  const draggingProjectId = useRef<string | null>(null);
   const editRef = useRef<string>("");
   const dialogProject = workspaceDialogProjectId
     ? (projects.find((p) => p.id === workspaceDialogProjectId) ?? null)
@@ -680,6 +684,59 @@ export function Sidebar() {
     [setActiveWorkspace],
   );
 
+  const clearWsDragState = useCallback(() => {
+    setDraggingWsId(null);
+    setDragOverWsId(null);
+    draggingProjectId.current = null;
+  }, []);
+
+  const handleWsDragStart = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, ws: { id: string; projectId: string; isRoot?: boolean }) => {
+      if (ws.isRoot) {
+        e.preventDefault();
+        return;
+      }
+      setDraggingWsId(ws.id);
+      setDragOverWsId(null);
+      draggingProjectId.current = ws.projectId;
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", ws.id);
+    },
+    [],
+  );
+
+  const handleWsDragOver = useCallback(
+    (e: React.DragEvent<HTMLElement>, ws: { id: string; projectId: string; isRoot?: boolean }) => {
+      if (!draggingWsId) return;
+      if (ws.isRoot || ws.projectId !== draggingProjectId.current) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      if (ws.id === draggingWsId) {
+        setDragOverWsId(null);
+        return;
+      }
+      setDragOverWsId(ws.id);
+    },
+    [draggingWsId],
+  );
+
+  const handleWsDrop = useCallback(
+    (e: React.DragEvent<HTMLElement>, ws: { id: string; projectId: string; isRoot?: boolean }) => {
+      if (!draggingWsId || !draggingProjectId.current) return;
+      e.preventDefault();
+      if (ws.isRoot || ws.projectId !== draggingProjectId.current) {
+        clearWsDragState();
+        return;
+      }
+      const sourceId = e.dataTransfer.getData("text/plain") || draggingWsId;
+      if (sourceId !== ws.id) {
+        reorderWorkspace(draggingProjectId.current, sourceId, ws.id);
+      }
+      clearWsDragState();
+    },
+    [draggingWsId, clearWsDragState, reorderWorkspace],
+  );
+
   const handleDeleteWorkspace = useCallback(
     (e: React.MouseEvent, ws: { id: string; name: string; isRoot?: boolean }) => {
       e.stopPropagation();
@@ -842,9 +899,10 @@ export function Sidebar() {
                     return (
                       <div
                         key={ws.id}
+                        draggable={!ws.isRoot}
                         className={`${styles.workspaceItem} ${
                           ws.id === activeWorkspaceId ? styles.active : ""
-                        } ${unreadWorkspaceIds.has(ws.id) ? styles.unread : ""} ${activeAgentWorkspaceIds.has(ws.id) ? styles.claudeActive : ""} ${ws.isRoot ? styles.rootWorkspace : ""}`}
+                        } ${unreadWorkspaceIds.has(ws.id) ? styles.unread : ""} ${activeAgentWorkspaceIds.has(ws.id) ? styles.claudeActive : ""} ${ws.isRoot ? styles.rootWorkspace : ""} ${draggingWsId === ws.id ? styles.wsDragging : ""} ${dragOverWsId === ws.id ? styles.wsDragOver : ""}`}
                         onClick={() =>
                           !isEditing && handleSelectWorkspace(ws.id)
                         }
@@ -852,6 +910,10 @@ export function Sidebar() {
                           editRef.current = displayName;
                           setEditingWorkspaceId(ws.id);
                         }}
+                        onDragStart={(e) => handleWsDragStart(e, ws)}
+                        onDragOver={(e) => handleWsDragOver(e, ws)}
+                        onDrop={(e) => handleWsDrop(e, ws)}
+                        onDragEnd={clearWsDragState}
                       >
                         <span className={styles.workspaceIcon}>
                           {ws.isRoot ? "~" : ws.automationId ? "⏱" : "⌥"}

--- a/desktop/src/renderer/store/app-store.ts
+++ b/desktop/src/renderer/store/app-store.ts
@@ -283,6 +283,33 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     }),
 
+  reorderWorkspace: (projectId, sourceWsId, targetWsId) =>
+    set((s) => {
+      if (sourceWsId === targetWsId) return s
+
+      const source = s.workspaces.find((w) => w.id === sourceWsId)
+      const target = s.workspaces.find((w) => w.id === targetWsId)
+      if (!source || !target) return s
+      if (source.projectId !== projectId || target.projectId !== projectId) return s
+      if (source.isRoot || target.isRoot) return s
+
+      const nonRoot = s.workspaces.filter((w) => w.projectId === projectId && !w.isRoot)
+      const srcIdx = nonRoot.findIndex((w) => w.id === sourceWsId)
+      const tgtIdx = nonRoot.findIndex((w) => w.id === targetWsId)
+      if (srcIdx < 0 || tgtIdx < 0) return s
+
+      const reordered = [...nonRoot]
+      const [moved] = reordered.splice(srcIdx, 1)
+      reordered.splice(tgtIdx, 0, moved)
+
+      let cursor = 0
+      return {
+        workspaces: s.workspaces.map((w) =>
+          w.projectId === projectId && !w.isRoot ? reordered[cursor++] : w,
+        ),
+      }
+    }),
+
   setTerminalTitleFromCommand: (ptyId, command) =>
     set((s) => {
       const nextTitle = titleFromTerminalCommand(command)

--- a/desktop/src/renderer/store/types.ts
+++ b/desktop/src/renderer/store/types.ts
@@ -118,6 +118,7 @@ export interface AppState {
   removeTab: (id: string) => void
   setActiveTab: (id: string | null) => void
   moveTabInActiveWorkspace: (sourceTabId: string, targetTabId: string) => void
+  reorderWorkspace: (projectId: string, sourceWsId: string, targetWsId: string) => void
   setTerminalTitleFromCommand: (ptyId: string, command: string) => void
   setRightPanelMode: (mode: RightPanelMode) => void
   toggleRightPanel: () => void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the ability to drag-to-reorder workspaces within each project in the sidebar. The root workspace always stays pinned first and is not draggable.

### Demo

<a href="https://cursor.com/agents/bc-f7a9db40-20c6-4701-a673-abccb535a8f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkspace_drag_reorder_playwright_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b6312ccc-b6ba-4b2c-b2d1-90c5ad40ff01" alt="workspace_drag_reorder_playwright_demo.mp4" /></a>

Playwright-driven drag-to-reorder: workspaces are reordered via drag-and-drop, root stays pinned first.

![Before drag — initial workspace order](https://cursor.com/artifacts/c/art-d82afc5f-6af8-43f1-b669-c5fcba283810)
![After first drag — refactor-api moved above feature-auth](https://cursor.com/artifacts/c/art-14fcea01-e3d8-4936-bbac-89bb0ab54323)
![After second drag — feature-dashboard moved up](https://cursor.com/artifacts/c/art-d826352a-8740-45cd-ac50-dca6bb8852ce)

### Changes

- **Store** (`app-store.ts`, `types.ts`): Added `reorderWorkspace(projectId, sourceWsId, targetWsId)` action that reorders non-root workspaces within a project, using the same array-splice pattern as `moveTabInActiveWorkspace`.
- **Sidebar** (`Sidebar.tsx`): Added HTML5 drag-and-drop handlers (`onDragStart`, `onDragOver`, `onDrop`, `onDragEnd`) on workspace items. Root workspaces are not draggable and cannot be drop targets. Drag is scoped to the same project.
- **Styles** (`Sidebar.module.css`): Added `.wsDragging` (opacity fade) and `.wsDragOver` (blue bottom border) visual feedback classes.

### Behavior

- Root workspace (marked with `~`) always stays first — it is not draggable and cannot be a drop target
- Non-root workspaces can be freely reordered via drag-and-drop within their project
- Drag across projects is prevented
- Order persists via the existing state auto-save mechanism
- Visual feedback: dragged item fades, drop target shows a blue bottom indicator line

### Testing

- All 73 existing e2e tests pass
- Dedicated Playwright drag-to-reorder test verifies: reorder works, root stays pinned
- TypeScript compiles with no errors
- Production build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7a9db40-20c6-4701-a673-abccb535a8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7a9db40-20c6-4701-a673-abccb535a8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

