### PR TITLE
perf: batch PR review thread counts into main query

### DIFF
--- a/desktop/src/main/github-service.ts
+++ b/desktop/src/main/github-service.ts
@@ -37,6 +37,13 @@ interface GraphqlPullRequestNode {
       }
     }>
   }
+  reviewThreads?: {
+    nodes?: Array<{ isResolved?: boolean }>
+    pageInfo?: {
+      hasNextPage?: boolean
+      endCursor?: string | null
+    }
+  }
 }
 
 interface GraphqlConnection {
@@ -466,6 +473,15 @@ export class GithubService {
             }
           }
         }
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
       }
     `
 
@@ -499,6 +515,15 @@ export class GithubService {
                       state
                     }
                   }
+                }
+              }
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
                 }
               }
             }
@@ -597,6 +622,41 @@ export class GithubService {
     prNode: GraphqlPullRequestNode,
     info: PrInfo
   ): Promise<void> {
+    const inline = prNode.reviewThreads
+    if (inline) {
+      const nodes = Array.isArray(inline.nodes) ? inline.nodes : []
+      const inlineUnresolved = nodes.filter((t) => !t.isResolved).length
+      if (!inline.pageInfo?.hasNextPage) {
+        info.pendingCommentCount = inlineUnresolved
+        info.hasPendingComments = inlineUnresolved > 0
+        this.updateReviewThreadCache(repoInfo, prNode.number, prNode.updatedAt, inlineUnresolved)
+        return
+      }
+
+      const key = this.reviewThreadCacheKey(repoInfo, prNode.number, prNode.updatedAt)
+      const cached = this.unresolvedThreadCache.get(key)
+      if (
+        cached &&
+        Date.now() - cached.fetchedAt < this.UNRESOLVED_THREAD_CACHE_TTL_MS
+      ) {
+        info.pendingCommentCount = cached.count
+        info.hasPendingComments = cached.count > 0
+        return
+      }
+
+      const remaining = await this.fetchUnresolvedReviewThreadCount(
+        repoInfo,
+        token,
+        prNode.number,
+        inline.pageInfo.endCursor ?? null
+      )
+      const total = inlineUnresolved + remaining
+      info.pendingCommentCount = total
+      info.hasPendingComments = total > 0
+      this.updateReviewThreadCache(repoInfo, prNode.number, prNode.updatedAt, total)
+      return
+    }
+
     const key = this.reviewThreadCacheKey(repoInfo, prNode.number, prNode.updatedAt)
     const cached = this.unresolvedThreadCache.get(key)
     if (
@@ -608,7 +668,7 @@ export class GithubService {
       return
     }
 
-    const unresolvedCount = await this.fetchUnresolvedReviewThreadCount(repoInfo, token, prNode.number)
+    const unresolvedCount = await this.fetchUnresolvedReviewThreadCount(repoInfo, token, prNode.number, null)
     info.pendingCommentCount = unresolvedCount
     info.hasPendingComments = unresolvedCount > 0
     this.updateReviewThreadCache(repoInfo, prNode.number, prNode.updatedAt, unresolvedCount)
@@ -617,9 +677,10 @@ export class GithubService {
   private static async fetchUnresolvedReviewThreadCount(
     repoInfo: GithubRepoInfo,
     token: string,
-    number: number
+    number: number,
+    startCursor: string | null
   ): Promise<number> {
-    let cursor: string | null = null
+    let cursor: string | null = startCursor
     let unresolvedCount = 0
 
     while (true) {


### PR DESCRIPTION
## Summary

- Fold `reviewThreads(first: 100)` into the main PR GraphQL fragment + open PR list query so pending-comment counts return inline with PR status.
- Fall back to the paginated query only when a PR has >100 threads, resuming from the inline `endCursor` instead of restarting.
- Cuts PR status polling from `1 + N` GraphQL requests per cycle to `1` (where N = open PRs per project).

## Why

With many workspaces open, the old approach was blowing through GitHub's 5000-point/hour authenticated rate limit. For a project with ~10 open PRs, this cuts request volume by ~90%.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bunx playwright test e2e/pr-status.spec.ts` — all 10 tests pass
- [x] Live GitHub API check: batched query returns correct unresolved counts (verified PR #6 shows 3 unresolved inline, cost = 1 point)
- [ ] Manual: run `bun run dev`, confirm pending-comment count and "Ready" badge still render correctly across open PRs